### PR TITLE
Add backwards compatibility

### DIFF
--- a/Service/EventBridgeNotifier.php
+++ b/Service/EventBridgeNotifier.php
@@ -22,22 +22,22 @@ class EventBridgeNotifier implements NotifierInterface
     /**
      * @var Json
      */
-    private Json $json;
+    private $json;
 
     /**
      * @var EncryptorInterface
      */
-    private EncryptorInterface $encryptor;
+    private $encryptor;
 
     /**
      * @var LoggerInterface
      */
-    private LoggerInterface $logger;
+    private $logger;
 
     /**
      * @var EventBridgeConfig
      */
-    private EventBridgeConfig $config;
+    private $config;
 
     /**
      * @var EventBridgeClient

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "registration.php"
     ],
     "psr-4": {
-      "Aligent\\Webhooks\\": ""
+      "Aligent\\EventBridge\\": ""
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "An AWS EventBridge notifier backed by the aligent/magento2-webhooks module.",
   "type": "magento2-module",
   "require": {
-    "php":  "~7.4.0",
+    "php":  ">=7.0",
     "magento/framework": "*",
     "aws/aws-sdk-php": "^3.110"
   },


### PR DESCRIPTION
Following suite with webhooks module adding support for `php: '>= 7.0'`

Also fixes a major bug where the auto load namespace was incorrect which caused issues when this module is required via composer in other projects.
